### PR TITLE
Correction of the wrong argument name in the sample1_helloword.py example

### DIFF
--- a/Python/Batch/sample1_helloworld.py
+++ b/Python/Batch/sample1_helloworld.py
@@ -105,7 +105,7 @@ def execute_sample(global_config, sample_config):
 
     batch_client = batch.BatchServiceClient(
         credentials,
-        base_url=batch_service_url)
+        batch_url=batch_service_url)
 
     # Retry 5 times -- default is 3
     batch_client.config.retry_policy.retries = 5


### PR DESCRIPTION
Concerns issue #267
Correcting the wrong argument name in the example that causes the exception during startup:
 **base_url**  -->  **batch_url**
Wrong name caused the error at run time:
```
TypeError: __init__() got an unexpected keyword argument 'base_url'
```