### PR TITLE
Fix C# Samples "Text Search"

### DIFF
--- a/CSharp/TextSearch/Common/Constants.cs
+++ b/CSharp/TextSearch/Common/Constants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
     /// </summary>
     public static class Constants
     {
-        public const string JobManagerExecutable = "JobManagerTask.exe";
+        public const string JobManagerExecutable = "JobSubmitter.exe";
         public const string MapperTaskExecutable = "MapperTask.exe";
         public const string ReducerTaskExecutable = "ReducerTask.exe";
         public const string ReducerTaskResultBlobName = "ReducerTaskOutput";
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
             {
                 JobManagerExecutable,
                 JobManagerExecutable + ".config",
-                "JobManagerTask.pdb",
+                "JobSubmitter.pdb",
                 MapperTaskExecutable,
                 MapperTaskExecutable + ".config",
                 "MapperTask.pdb",

--- a/CSharp/TextSearch/Common/Constants.cs
+++ b/CSharp/TextSearch/Common/Constants.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
     /// </summary>
     public static class Constants
     {
-        public const string JobManagerExecutable = "JobSubmitter.exe";
         public const string MapperTaskExecutable = "MapperTask.exe";
         public const string ReducerTaskExecutable = "ReducerTask.exe";
         public const string ReducerTaskResultBlobName = "ReducerTaskOutput";
@@ -24,9 +23,7 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
         /// </summary>
         public readonly static IReadOnlyList<string> RequiredExecutableFiles = new List<string>
             {
-                JobManagerExecutable,
-                JobManagerExecutable + ".config",
-                "JobSubmitter.pdb",
+	            "JobSubmitter.pdb",
                 MapperTaskExecutable,
                 MapperTaskExecutable + ".config",
                 "MapperTask.pdb",


### PR DESCRIPTION
There was a little error in the Constants class for the C# Samples "TextSearch".
If you run the sample project, it crash because search an .exe file that didn't exist ("JobManagerTask").