### PR TITLE
Updated Pool creation to use VirtualMachineConfiguration

### DIFF
--- a/CSharp/ArticleProjects/ApplicationInsights/README.md
+++ b/CSharp/ArticleProjects/ApplicationInsights/README.md
@@ -310,9 +310,16 @@ binaries on the machine and keep a process running indefinitely.
 CloudPool pool = client.PoolOperations.CreatePool(
     topNWordsConfiguration.PoolId,
     targetDedicated: topNWordsConfiguration.PoolNodeCount,
-    virtualMachineSize: "standard_d1_v2",
-    cloudServiceConfiguration: new CloudServiceConfiguration(osFamily: "5"));
-
+    virtualMachineSize: "standard_d2_v3",
+    virtualMachineConfiguration: new VirtualMachineConfiguration(
+    imageReference: new ImageReference(
+            publisher: topNWordsConfiguration.ImagePublisher,
+            offer: topNWordsConfiguration.ImageOffer,
+            sku: topNWordsConfiguration.ImageSku,
+            version: topNWordsConfiguration.ImageVersion
+        ),
+    nodeAgentSkuId: topNWordsConfiguration.NodeAgentSkuId));
+    
 // Create file staging objects that represent the executable and its dependent assembly to run as the task.
 // These files are copied to every node before the corresponding task is scheduled to run on that node.
 FileToStage applicationMonitoringExe = new FileToStage(BatchApplicationInsightsAssemblyExeName, stagingStorageAccount);

--- a/CSharp/ArticleProjects/ApplicationInsights/TopNWords/Job.cs
+++ b/CSharp/ArticleProjects/ApplicationInsights/TopNWords/Job.cs
@@ -83,8 +83,15 @@ namespace Microsoft.Azure.Batch.Samples.TopNWordsSample
                 CloudPool pool = client.PoolOperations.CreatePool(
                     topNWordsConfiguration.PoolId,
                     targetDedicatedComputeNodes: topNWordsConfiguration.PoolNodeCount,
-                    virtualMachineSize: "standard_d1_v2",
-                    cloudServiceConfiguration: new CloudServiceConfiguration(osFamily: "5"));
+                    virtualMachineSize: topNWordsConfiguration.PoolNodeVirtualMachineSize,
+                    virtualMachineConfiguration: new VirtualMachineConfiguration(
+                    imageReference: new ImageReference(
+                            publisher: topNWordsConfiguration.ImagePublisher,
+                            offer: topNWordsConfiguration.ImageOffer,
+                            sku: topNWordsConfiguration.ImageSku,
+                            version: topNWordsConfiguration.ImageVersion
+                        ),
+                    nodeAgentSkuId: topNWordsConfiguration.NodeAgentSkuId));
 
                 List<string> files = new List<string>
                 {

--- a/CSharp/ArticleProjects/ApplicationInsights/TopNWords/Settings.cs
+++ b/CSharp/ArticleProjects/ApplicationInsights/TopNWords/Settings.cs
@@ -16,5 +16,11 @@ namespace Microsoft.Azure.Batch.Samples.TopNWordsSample
         public bool ShouldDeleteJob { get; set; }
         public bool ShouldDeletePool { get; set; }
         public bool ShouldDeleteContainer { get; set; }
+        public string PoolNodeVirtualMachineSize { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }           
     }
 }

--- a/CSharp/ArticleProjects/ApplicationInsights/TopNWords/settings.json
+++ b/CSharp/ArticleProjects/ApplicationInsights/TopNWords/settings.json
@@ -6,5 +6,11 @@
   "shouldDeletePool": false,
   "shouldDeleteContainer": true,
   "poolId": "TopNWordsPool",
-  "jobId": "TopNWordsJob"
+  "jobId": "TopNWordsJob",
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"   
 }

--- a/CSharp/ArticleProjects/JobPrepRelease/Program.cs
+++ b/CSharp/ArticleProjects/JobPrepRelease/Program.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Batch.Samples.Articles.JobPrepRelease
                 CloudPool pool = await ArticleHelpers.CreatePoolIfNotExistAsync(
                     batchClient,
                     poolId,
-                    "standard_d1_v2",
+                    "standard_d2_v3",
                     2,
                     1);
                 

--- a/CSharp/ArticleProjects/MultiInstanceTasks/Program.cs
+++ b/CSharp/ArticleProjects/MultiInstanceTasks/Program.cs
@@ -198,10 +198,17 @@ namespace Microsoft.Azure.Batch.Samples.MultiInstanceTasks
             CloudPool unboundPool =
                 batchClient.PoolOperations.CreatePool(
                     poolId: poolId,
-                    virtualMachineSize: "standard_d1_v2",
+                    virtualMachineSize: "standard_d2_v3",
                     targetDedicatedComputeNodes: numberOfNodes,
-                    cloudServiceConfiguration: new CloudServiceConfiguration(osFamily: "5"));
-
+                    virtualMachineConfiguration: new VirtualMachineConfiguration(
+                    imageReference: new ImageReference(
+                            publisher: "MicrosoftWindowsServer",
+                            offer: "WindowsServer",
+                            sku: "2016-Datacenter-smalldisk",
+                            version: "latest"
+                        ),
+                    nodeAgentSkuId: "batch.node.windows amd64"));
+                    
             // REQUIRED for communication between the MS-MPI processes (in this
             // sample, MPIHelloWorld.exe) running on the different nodes
             unboundPool.InterComputeNodeCommunicationEnabled = true;

--- a/CSharp/ArticleProjects/ParallelTasks/Program.cs
+++ b/CSharp/ArticleProjects/ParallelTasks/Program.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Batch.Samples.Articles.ParallelTasks
         private static async Task MainAsync(string[] args)
         {
             // You may adjust these values to experiment with different compute resource scenarios.
-            const string nodeSize      = "standard_d1_v2";
+            const string nodeSize      = "standard_d2_v3";
             const int nodeCount        = 4;
             const int taskSlotsPerNode = 4;
             const int taskCount        = 32;

--- a/CSharp/ArticleProjects/PersistOutputs/OutputFilesExample.cs
+++ b/CSharp/ArticleProjects/PersistOutputs/OutputFilesExample.cs
@@ -191,7 +191,7 @@
 
             // Create and configure an unbound pool.
             CloudPool pool = batchClient.PoolOperations.CreatePool(poolId: poolId,
-                virtualMachineSize: "standard_d1_v2",
+                virtualMachineSize: "standard_d2_v3",
                 targetDedicatedComputeNodes: nodeCount,
                 virtualMachineConfiguration: new VirtualMachineConfiguration(
                     imageInfo.ImageReference,

--- a/CSharp/ArticleProjects/TaskDependencies/Program.cs
+++ b/CSharp/ArticleProjects/TaskDependencies/Program.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Batch.Samples.Articles.TaskDependencies
         private static async Task MainAsync(string[] args)
         {
             // You may adjust these values to experiment with different compute resource scenarios.
-            const string nodeSize = "standard_d1_v2";
+            const string nodeSize = "standard_d2_v3";
             const string osFamily = "5";
             const int nodeCount = 1;
 
@@ -66,8 +66,15 @@ namespace Microsoft.Azure.Batch.Samples.Articles.TaskDependencies
                     CloudPool unboundPool =
                         batchClient.PoolOperations.CreatePool(
                             poolId: poolId,
-                            cloudServiceConfiguration: new CloudServiceConfiguration(osFamily),
-                            virtualMachineSize: nodeSize,
+                            virtualMachineSize: "standard_d2_v3",
+                            virtualMachineConfiguration: new VirtualMachineConfiguration(
+                            imageReference: new ImageReference(
+                                    publisher: "MicrosoftWindowsServer",
+                                    offer: "WindowsServer",
+                                    sku: "2016-Datacenter-smalldisk",
+                                    version: "latest"
+                                ),
+                            nodeAgentSkuId: "batch.node.windows amd64"),
                             targetDedicatedComputeNodes: nodeCount);
                     await unboundPool.CommitAsync();
 

--- a/CSharp/BatchMetrics/BatchMetricsUsageSample/JobSubmitter.cs
+++ b/CSharp/BatchMetrics/BatchMetricsUsageSample/JobSubmitter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Batch.Samples.BatchMetricsUsageSample
 
         private const string PoolId = "batchmetrics-testpool";
         private const int PoolNodeCount = 5;
-        private const string PoolNodeSize = "small";
+        private const string PoolNodeSize = "standard_d2_v3";
         private const string PoolOSFamily = "4";
 
         private const int TestJobCount = 10;
@@ -46,8 +46,14 @@ namespace Microsoft.Azure.Batch.Samples.BatchMetricsUsageSample
                 poolId: PoolId,
                 targetDedicatedComputeNodes: PoolNodeCount,
                 virtualMachineSize: PoolNodeSize,
-                cloudServiceConfiguration: new CloudServiceConfiguration(PoolOSFamily));
-
+                virtualMachineConfiguration: new VirtualMachineConfiguration(
+                imageReference: new ImageReference(
+                        publisher: "MicrosoftWindowsServer",
+                        offer: "WindowsServer",
+                        sku: "2016-Datacenter-smalldisk",
+                        version: "latest"
+                    ),
+                nodeAgentSkuId: "batch.node.windows amd64"));
             pool.TaskSlotsPerNode = 2;
 
             var createPoolResult = await GettingStartedCommon.CreatePoolIfNotExistAsync(this.batchClient, pool);

--- a/CSharp/Common/ArticleHelpers.cs
+++ b/CSharp/Common/ArticleHelpers.cs
@@ -29,7 +29,14 @@ namespace Microsoft.Azure.Batch.Samples.Common
             CloudPool pool = batchClient.PoolOperations.CreatePool(poolId: poolId,
                 virtualMachineSize: nodeSize,
                 targetDedicatedComputeNodes: nodeCount,
-                cloudServiceConfiguration: new CloudServiceConfiguration("5"));
+                virtualMachineConfiguration: new VirtualMachineConfiguration(
+                imageReference: new ImageReference(
+                        publisher: "MicrosoftWindowsServer",
+                        offer: "WindowsServer",
+                        sku: "2016-Datacenter-smalldisk",
+                        version: "latest"
+                    ),
+                nodeAgentSkuId: "batch.node.windows amd64"));
 
             pool.TaskSlotsPerNode = taskSlotsPerNode;
 

--- a/CSharp/GettingStarted/01_HelloWorld/Program.cs
+++ b/CSharp/GettingStarted/01_HelloWorld/Program.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
             try
             {
                 AccountSettings accountSettings = SampleHelpers.LoadAccountSettings();
-                VirtualMachineSettings virtualMachineSettings = SampleHelpers.LoadVirtualMachineSettings();
                 Settings helloWorldSettings = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("settings.json")

--- a/CSharp/GettingStarted/01_HelloWorld/Program.cs
+++ b/CSharp/GettingStarted/01_HelloWorld/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
             try
             {
                 AccountSettings accountSettings = SampleHelpers.LoadAccountSettings();
-
+                VirtualMachineSettings virtualMachineSettings = SampleHelpers.LoadVirtualMachineSettings();
                 Settings helloWorldSettings = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("settings.json")
@@ -49,7 +49,9 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
         /// <summary>
         /// Submits a job to the Azure Batch service, and waits for it to complete
         /// </summary>
-        private static async Task HelloWorldAsync(AccountSettings accountSettings, Settings helloWorldConfigurationSettings)
+        private static async Task HelloWorldAsync(
+            AccountSettings accountSettings, 
+            Settings helloWorldConfigurationSettings)
         {
             Console.WriteLine("Running with the following settings: ");
             Console.WriteLine("-------------------------------------");
@@ -97,7 +99,10 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
         /// <param name="configurationSettings">The configuration settings</param>
         /// <param name="jobId">The ID of the job.</param>
         /// <returns>An asynchronous <see cref="Task"/> representing the operation.</returns>
-        private static async Task SubmitJobAsync(BatchClient batchClient, Settings configurationSettings, string jobId)
+        private static async Task SubmitJobAsync(
+            BatchClient batchClient, 
+            Settings configurationSettings,
+            string jobId)
         {
             // create an empty unbound Job
             CloudJob unboundJob = batchClient.JobOperations.CreateJob();
@@ -112,8 +117,15 @@ namespace Microsoft.Azure.Batch.Samples.HelloWorld
                     PoolSpecification = new PoolSpecification()
                     {
                         TargetDedicatedComputeNodes = configurationSettings.PoolTargetNodeCount,
-                        CloudServiceConfiguration = new CloudServiceConfiguration(configurationSettings.PoolOSFamily),
-                        VirtualMachineSize = configurationSettings.PoolNodeVirtualMachineSize
+                        VirtualMachineSize = configurationSettings.PoolNodeVirtualMachineSize,
+                        VirtualMachineConfiguration = new VirtualMachineConfiguration(
+                        imageReference: new ImageReference(
+                                publisher: configurationSettings.ImagePublisher,
+                                offer: configurationSettings.ImageOffer,
+                                sku: configurationSettings.ImageSku,
+                                version: configurationSettings.ImageVersion
+                            ),
+                        nodeAgentSkuId: configurationSettings.NodeAgentSkuId),
                     },
                     KeepAlive = false,
                     PoolLifetimeOption = PoolLifetimeOption.Job

--- a/CSharp/GettingStarted/01_HelloWorld/Settings.cs
+++ b/CSharp/GettingStarted/01_HelloWorld/Settings.cs
@@ -10,6 +10,11 @@
         public string PoolOSFamily { get; set; }
         public string PoolNodeVirtualMachineSize { get; set; }
         public bool ShouldDeleteJob { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }
 
         public override string ToString()
         {
@@ -20,6 +25,12 @@
             SampleHelpers.AddSetting(stringBuilder, "PoolOSFamily", this.PoolOSFamily);
             SampleHelpers.AddSetting(stringBuilder, "PoolNodeVirtualMachineSize", this.PoolNodeVirtualMachineSize);
             SampleHelpers.AddSetting(stringBuilder, "ShouldDeleteJob", this.ShouldDeleteJob);
+            SampleHelpers.AddSetting(stringBuilder, "ImagePublisher", this.ImagePublisher);
+            SampleHelpers.AddSetting(stringBuilder, "ImageOffer", this.ImageOffer);
+            SampleHelpers.AddSetting(stringBuilder, "ImageSku", this.ImageSku);
+            SampleHelpers.AddSetting(stringBuilder, "ImageVersion", this.ImageVersion);
+            SampleHelpers.AddSetting(stringBuilder, "NodeAgentSkuId", this.NodeAgentSkuId);
+
 
             return stringBuilder.ToString();
         }

--- a/CSharp/GettingStarted/01_HelloWorld/settings.json
+++ b/CSharp/GettingStarted/01_HelloWorld/settings.json
@@ -1,7 +1,12 @@
 ﻿{
   "poolTargetNodeCount": 2,
-  "poolNodeVirtualMachineSize": "standard_d1_v2",
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
   "poolOSFamily": "5",
   "poolId": "HelloWorld-Pool",
-  "shouldDeleteJob":  true
+  "shouldDeleteJob": true,
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"
 }

--- a/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/JobSubmitter.cs
+++ b/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/JobSubmitter.cs
@@ -128,13 +128,21 @@ namespace Microsoft.Azure.Batch.Samples.PoolsAndResourceFiles
         /// <returns>An asynchronous <see cref="Task"/> representing the operation.</returns>
         private async Task CreatePoolIfNotExistAsync(BatchClient batchClient, CloudStorageAccount cloudStorageAccount)
         {
+
             // You can learn more about os families and versions at:
             // https://azure.microsoft.com/en-us/documentation/articles/cloud-services-guestos-update-matrix/
             CloudPool pool = batchClient.PoolOperations.CreatePool(
                 poolId: this.poolsAndResourceFileSettings.PoolId,
                 targetDedicatedComputeNodes: this.poolsAndResourceFileSettings.PoolTargetNodeCount,
                 virtualMachineSize: this.poolsAndResourceFileSettings.PoolNodeVirtualMachineSize,
-                cloudServiceConfiguration: new CloudServiceConfiguration(this.poolsAndResourceFileSettings.PoolOsFamily));
+                virtualMachineConfiguration: new VirtualMachineConfiguration(
+                        imageReference: new ImageReference(
+                                publisher: poolsAndResourceFileSettings.ImagePublisher,
+                                offer: poolsAndResourceFileSettings.ImageOffer,
+                                sku: poolsAndResourceFileSettings.ImageSku,
+                                version: poolsAndResourceFileSettings.ImageVersion
+                            ),
+                        nodeAgentSkuId: poolsAndResourceFileSettings.NodeAgentSkuId));
 
             // Create a new start task to facilitate pool-wide file management or installation.
             // In this case, we just add a single dummy data file to the StartTask.

--- a/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/Settings.cs
+++ b/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/Settings.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.Batch.Samples.PoolsAndResourceFiles
         public bool ShouldDeletePool { get; set; }
         public bool ShouldDeleteJob { get; set; }
         public string BlobContainer { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }        
 
         public override string ToString()
         {
@@ -26,6 +31,11 @@ namespace Microsoft.Azure.Batch.Samples.PoolsAndResourceFiles
             SampleHelpers.AddSetting(stringBuilder, "ShouldDeletePool", this.ShouldDeletePool);
             SampleHelpers.AddSetting(stringBuilder, "ShouldDeleteJob", this.ShouldDeleteJob);
             SampleHelpers.AddSetting(stringBuilder, "BlobContainer", this.BlobContainer);
+            SampleHelpers.AddSetting(stringBuilder, "ImagePublisher", this.ImagePublisher);
+            SampleHelpers.AddSetting(stringBuilder, "ImageOffer", this.ImageOffer);
+            SampleHelpers.AddSetting(stringBuilder, "ImageSku", this.ImageSku);
+            SampleHelpers.AddSetting(stringBuilder, "ImageVersion", this.ImageVersion);
+            SampleHelpers.AddSetting(stringBuilder, "NodeAgentSkuId", this.NodeAgentSkuId);
             
             return stringBuilder.ToString();
         }

--- a/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/settings.json
+++ b/CSharp/GettingStarted/02_PoolsAndResourceFiles/JobSubmitter/settings.json
@@ -1,9 +1,14 @@
 ﻿{
   "poolTargetNodeCount": 2,
-  "poolNodeVirtualMachineSize": "standard_d1_v2",
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
   "poolOSFamily": "5",
   "poolId": "PoolsAndResourceFilesPool",
   "shouldDeleteJob": true,
   "shouldDeletePool": false,
-  "blobContainer": "PoolAndResourceFilesContainer"
+  "blobContainer": "PoolAndResourceFilesContainer",
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"  
 }

--- a/CSharp/GettingStarted/03_JobManager/JobSubmitter/JobSubmitter.cs
+++ b/CSharp/GettingStarted/03_JobManager/JobSubmitter/JobSubmitter.cs
@@ -140,7 +140,14 @@ namespace Microsoft.Azure.Batch.Samples.JobManager
                 poolId: this.jobManagerSettings.PoolId,
                 targetDedicatedComputeNodes: this.jobManagerSettings.PoolTargetNodeCount,
                 virtualMachineSize: this.jobManagerSettings.PoolNodeVirtualMachineSize,
-                cloudServiceConfiguration: new CloudServiceConfiguration(this.jobManagerSettings.PoolOsFamily));
+                virtualMachineConfiguration: new VirtualMachineConfiguration(
+                        imageReference: new ImageReference(
+                                publisher: jobManagerSettings.ImagePublisher,
+                                offer: jobManagerSettings.ImageOffer,
+                                sku: jobManagerSettings.ImageSku,
+                                version: jobManagerSettings.ImageVersion
+                            ),
+                        nodeAgentSkuId: jobManagerSettings.NodeAgentSkuId));
 
             // Create a new start task to facilitate pool-wide file management or installation.
             // In this case, we just add a single dummy data file to the StartTask.

--- a/CSharp/GettingStarted/03_JobManager/JobSubmitter/Settings.cs
+++ b/CSharp/GettingStarted/03_JobManager/JobSubmitter/Settings.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.Batch.Samples.JobManager
         public bool ShouldDeletePool { get; set; }
         public bool ShouldDeleteJob { get; set; }
         public string BlobContainer { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }        
 
         public override string ToString()
         {
@@ -26,7 +31,12 @@ namespace Microsoft.Azure.Batch.Samples.JobManager
             SampleHelpers.AddSetting(stringBuilder, "ShouldDeletePool", this.ShouldDeletePool);
             SampleHelpers.AddSetting(stringBuilder, "ShouldDeleteJob", this.ShouldDeleteJob);
             SampleHelpers.AddSetting(stringBuilder, "BlobContainer", this.BlobContainer);
-            
+            SampleHelpers.AddSetting(stringBuilder, "ImagePublisher", this.ImagePublisher);
+            SampleHelpers.AddSetting(stringBuilder, "ImageOffer", this.ImageOffer);
+            SampleHelpers.AddSetting(stringBuilder, "ImageSku", this.ImageSku);
+            SampleHelpers.AddSetting(stringBuilder, "ImageVersion", this.ImageVersion);
+            SampleHelpers.AddSetting(stringBuilder, "NodeAgentSkuId", this.NodeAgentSkuId);
+
             return stringBuilder.ToString();
         }
     }

--- a/CSharp/GettingStarted/03_JobManager/JobSubmitter/settings.json
+++ b/CSharp/GettingStarted/03_JobManager/JobSubmitter/settings.json
@@ -1,9 +1,14 @@
 ﻿{
   "poolTargetNodeCount": 2,
-  "poolNodeVirtualMachineSize": "standard_d1_v2",
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
   "poolOSFamily": "5",
   "poolId": "JobManagerSamplePool",
   "shouldDeleteJob": true,
   "shouldDeletePool": false,
-  "blobContainer": "JobManagerSampleContainer"
+  "blobContainer": "JobManagerSampleContainer",
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"  
 }

--- a/CSharp/TextSearch/Common/Settings.cs
+++ b/CSharp/TextSearch/Common/Settings.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
         public string OutputBlobContainer { get; set; }
         public int NumberOfMapperTasks { get; set; }
         public bool ShouldDeleteContainers { get; set; }
+        public string PoolNodeVirtualMachineSize { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }   
 
         public override string ToString()
         {
@@ -25,6 +31,11 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
             stringBuilder.AppendFormat("{0} = {1}", "InputBlobContainer", this.InputBlobContainer).AppendLine();
             stringBuilder.AppendFormat("{0} = {1}", "OutputBlobContainer", this.OutputBlobContainer).AppendLine();
             stringBuilder.AppendFormat("{0} = {1}", "ShouldDeleteContainers", this.ShouldDeleteContainers).AppendLine();
+            stringBuilder.AppendFormat("{0} = {1}", "PoolNodeVirtualMachineSize", this.PoolNodeVirtualMachineSize).AppendLine();
+            stringBuilder.AppendFormat("{0} = {1}", "ImagePublisher", this.ImagePublisher).AppendLine();
+            stringBuilder.AppendFormat("{0} = {1}", "ImageOffer", this.ImageOffer).AppendLine();
+            stringBuilder.AppendFormat("{0} = {1}", "ImageSku", this.ImageSku).AppendLine();
+            stringBuilder.AppendFormat("{0} = {1}", "NodeAgentSkuId", this.NodeAgentSkuId).AppendLine();
 
             return stringBuilder.ToString();
         }

--- a/CSharp/TextSearch/Common/settings.json
+++ b/CSharp/TextSearch/Common/settings.json
@@ -6,5 +6,11 @@
   "numberOfMapperTasks": 2,
   "inputBlobContainer": "textsearchinputcontainer",
   "outputBlobContainer": "textsearchoutputcontainer",
-  "shouldDeleteContainers":  true
+  "shouldDeleteContainers":  true,
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"      
 }

--- a/CSharp/TextSearch/JobSubmitter/JobSubmitter.cs
+++ b/CSharp/TextSearch/JobSubmitter/JobSubmitter.cs
@@ -113,10 +113,17 @@ namespace Microsoft.Azure.Batch.Samples.TextSearch
                 PoolSpecification poolSpecification = new PoolSpecification()
                 {
                     TargetDedicatedComputeNodes = numberOfPoolComputeNodes,
-                    VirtualMachineSize = "standard_d1_v2",
-                    //You can learn more about os families and versions at: 
-                    //http://azure.microsoft.com/documentation/articles/cloud-services-guestos-update-matrix
-                    CloudServiceConfiguration = new CloudServiceConfiguration(osFamily: "5")
+                    VirtualMachineSize = textSearchSettings.PoolNodeVirtualMachineSize,
+                    ////You can learn more about os families and versions at: 
+                    ////http://azure.microsoft.com/documentation/articles/cloud-services-guestos-update-matrix
+                    VirtualMachineConfiguration = new VirtualMachineConfiguration(
+                    imageReference: new ImageReference(
+                            publisher: textSearchSettings.ImagePublisher,
+                            offer: textSearchSettings.ImageOffer,
+                            sku: textSearchSettings.ImageSku,
+                            version: textSearchSettings.ImageVersion
+                        ),
+                    nodeAgentSkuId: textSearchSettings.NodeAgentSkuId),
                 };
 
                 //Use the auto pool feature of the Batch Service to create a pool when the job is created.

--- a/CSharp/TopNWords/Job.cs
+++ b/CSharp/TopNWords/Job.cs
@@ -60,8 +60,15 @@ namespace Microsoft.Azure.Batch.Samples.TopNWordsSample
                 CloudPool pool = client.PoolOperations.CreatePool(
                     topNWordsConfiguration.PoolId, 
                     targetDedicatedComputeNodes: topNWordsConfiguration.PoolNodeCount,
-                    virtualMachineSize: "standard_d1_v2",
-                    cloudServiceConfiguration: new CloudServiceConfiguration(osFamily: "5"));
+                    virtualMachineSize: topNWordsConfiguration.PoolNodeVirtualMachineSize,
+                    virtualMachineConfiguration: new VirtualMachineConfiguration(
+                    imageReference: new ImageReference(
+                            publisher: topNWordsConfiguration.ImagePublisher,
+                            offer: topNWordsConfiguration.ImageOffer,
+                            sku: topNWordsConfiguration.ImageSku,
+                            version: topNWordsConfiguration.ImageVersion
+                        ),
+                    nodeAgentSkuId: topNWordsConfiguration.NodeAgentSkuId));
                 Console.WriteLine("Adding pool {0}", topNWordsConfiguration.PoolId);
                 GettingStartedCommon.CreatePoolIfNotExistAsync(client, pool).Wait();
 

--- a/CSharp/TopNWords/Settings.cs
+++ b/CSharp/TopNWords/Settings.cs
@@ -17,5 +17,11 @@ namespace Microsoft.Azure.Batch.Samples.TopNWordsSample
         public bool ShouldDeleteJob { get; set; }
         public bool ShouldDeletePool { get; set; }
         public bool ShouldDeleteContainer { get; set; }
+        public string PoolNodeVirtualMachineSize { get; set; }
+        public string ImagePublisher { get; set; }
+        public string ImageOffer { get; set; }
+        public string ImageSku { get; set; }
+        public string ImageVersion { get; set; }
+        public string NodeAgentSkuId { get; set; }        
     }
 }

--- a/CSharp/TopNWords/settings.json
+++ b/CSharp/TopNWords/settings.json
@@ -7,5 +7,11 @@
   "shouldDeletePool": false,
   "shouldDeleteContainer": true,
   "poolId": "TopNWordsPool",
-  "jobId": "TopNWordsJob"
+  "jobId": "TopNWordsJob",
+  "poolNodeVirtualMachineSize": "standard_d2_v3",
+  "imagePublisher": "MicrosoftWindowsServer",
+  "imageOffer": "WindowsServer",
+  "imageSku": "2016-Datacenter-smalldisk",
+  "imageVersion": "latest",
+  "nodeAgentSkuId": "batch.node.windows amd64"    
 }


### PR DESCRIPTION
Modified the way Pools are created in the CSharp samples. The current samples use `CloudServiceConfiguration`, which will be retired and currently are not supported in some batch regions (see https://azure.microsoft.com/en-us/updates/azure-batch-cloudserviceconfiguration-pools-will-be-retired-on-29-february-2024/). 

Instead, the new version uses `VirtualMachineConfiguration`, with some backed-in settings. Sometimes, these are located in the sample-specific settings.json, while others they are in the code files themselves. 

Another small change is using `standard_d2_v3` instead of `standard_d1_v2`, as I found that new accounts might not have `standard_d1_v2` quota by default.