### PR TITLE
Fix deprecated Ubuntu pool images in Batch samples

### DIFF
--- a/JavaScript/Node.js/sample.js
+++ b/JavaScript/Node.js/sample.js
@@ -24,15 +24,15 @@ const jobId = "processcsvjob";
 
 // Pool VM Image Reference
 const imgRef = {
-    publisher: "Canonical",
-    offer: "UbuntuServer",
-    sku: "18.04-LTS",
+    publisher: "canonical",
+    offer: "ubuntu-24_04-lts",
+    sku: "server-gen1",
     version: "latest"
 }
 // Pool VM configuraion object
 const vmConfig = {
     imageReference: imgRef,
-    nodeAgentSKUId: "batch.node.ubuntu 18.04"
+    nodeAgentSKUId: "batch.node.ubuntu 24.04"
 };
 // Number of VMs to create in a pool
 const numVms = 4;

--- a/Python/Batch/sample1_helloworld.py
+++ b/Python/Batch/sample1_helloworld.py
@@ -56,10 +56,10 @@ def submit_job_and_add_task(
     vm_config = batchmodels.VirtualMachineConfiguration(
         image_reference=batchmodels.ImageReference(
             publisher="canonical",
-            offer="ubuntuserver",
-            sku="18.04-lts"
+            offer="ubuntu-24_04-lts",
+            sku="server-gen1"
         ),
-        node_agent_sku_id="batch.node.ubuntu 18.04"
+        node_agent_sku_id="batch.node.ubuntu 24.04"
     )
     pool_info = batchmodels.PoolInformation(
         auto_pool_specification=batchmodels.AutoPoolSpecification(

--- a/Python/Batch/sample1_jobprep_and_release.py
+++ b/Python/Batch/sample1_jobprep_and_release.py
@@ -56,10 +56,10 @@ def submit_job_with_prep_and_release_tasks(
     vm_config = batchmodels.VirtualMachineConfiguration(
         image_reference=batchmodels.ImageReference(
             publisher="canonical",
-            offer="ubuntuserver",
-            sku="18.04-lts"
+            offer="ubuntu-24_04-lts",
+            sku="server-gen1"
         ),
-        node_agent_sku_id="batch.node.ubuntu 18.04"
+        node_agent_sku_id="batch.node.ubuntu 24.04"
     )
     pool_info = batchmodels.PoolInformation(
         auto_pool_specification=batchmodels.AutoPoolSpecification(

--- a/Python/Batch/sample2_pools_and_resourcefiles.py
+++ b/Python/Batch/sample2_pools_and_resourcefiles.py
@@ -60,10 +60,10 @@ def create_pool(
     :param vm_size: vm size (sku)
     :param vm_count: number of vms to allocate
     """
-    # pick the latest supported 16.04 sku for UbuntuServer
+    # pick the latest supported Ubuntu 24.04 sku for Canonical
     sku_to_use, image_ref_to_use = \
         common.helpers.select_latest_verified_vm_image_with_node_agent_sku(
-            batch_client, 'canonical', 'ubuntuserver', '18.04')
+            batch_client, 'canonical', 'ubuntu-24_04-lts', 'server-gen1')
 
     try:
         blob_service_client.create_container(_CONTAINER_NAME)

--- a/Python/Batch/sample3_encrypted_resourcefiles.py
+++ b/Python/Batch/sample3_encrypted_resourcefiles.py
@@ -197,10 +197,10 @@ def create_pool_and_wait_for_node(
         virtual_machine_configuration=batchmodels.VirtualMachineConfiguration(
             image_reference=batchmodels.ImageReference(
                 publisher="canonical",
-                offer="0001-com-ubuntu-server-focal",
-                sku="20_04-lts"
+                offer="ubuntu-24_04-lts",
+                sku="server-gen1"
             ),
-            node_agent_sku_id="batch.node.ubuntu 20.04"),
+            node_agent_sku_id="batch.node.ubuntu 24.04"),
         vm_size=vm_size,
         target_dedicated_nodes=vm_count,
         start_task=batchmodels.StartTask(


### PR DESCRIPTION
## What

Several samples reference Ubuntu pool images that are no longer available in the Azure Marketplace / no longer supported by Batch node agents, so **pool allocation currently fails** with these samples:

- `UbuntuServer` `18.04-LTS` — the `UbuntuServer` offer now only publishes SKUs up to 16.04.
- `0001-com-ubuntu-server-focal` `20.04` — `batch.node.ubuntu 20.04` is no longer supported for new pools.

## Fix

Update them to **Ubuntu Server 24.04 LTS** (`canonical` / `ubuntu-24_04-lts` / `server-gen1`, node agent `batch.node.ubuntu 24.04`), which is currently Batch-verified (confirmed via `list_supported_images`).

The **Gen1** sku (`server-gen1`) is used intentionally so the pools keep booting on the existing default VM sizes (`Standard_DS1_V2` / `Standard_D1_V2`), which support Hyper-V Gen1 (V1) only.

## Affected samples

- `Python/Batch/sample1_helloworld.py`
- `Python/Batch/sample1_jobprep_and_release.py`
- `Python/Batch/sample2_pools_and_resourcefiles.py`
- `Python/Batch/sample3_encrypted_resourcefiles.py`
- `JavaScript/Node.js/sample.js`

## Validation

- `flake8` gate on `Python/Batch` passes.
- `py_compile` (Python) and `node --check` (JS) succeed.